### PR TITLE
feat: move to RPC for pull command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-sdk"
 edition = "2021"
-version = "0.5.0"
+version = "1.2.0"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -18,9 +18,9 @@ export default class Api {
   async pull(checkpoint) {
     await this.api.isReady;
     console.log(checkpoint);
-    let result = await this.api.rpc.mantaPay.pull(checkpoint);
+    let result = await this.api.rpc.mantaPay.pull_ledger_diff(checkpoint);
     console.log(result);
-    result
+    return result;
   }
 
   // Maps a transfer post object to its corresponding MantaPay extrinsic.

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -14,13 +14,31 @@ export default class Api {
     this.txResHandler = txResHandler;
   }
 
+  // Converts an `encrypted_note` into a JSON object.
+  _encrypted_note_to_json(encrypted_note) {
+    return  {
+        ephemeral_public_key: Array.from(encrypted_note.ephemeral_public_key.toU8a()),
+        ciphertext: Array.from(encrypted_note.ciphertext.toU8a()),
+    }
+  }
+
   // Pulls data from the ledger from the `checkpoint` or later, returning the new checkpoint.
   async pull(checkpoint) {
     await this.api.isReady;
     console.log(checkpoint);
     let result = await this.api.rpc.mantaPay.pull_ledger_diff(checkpoint);
     console.log(result);
-    return result;
+    const result2 = { should_continue: result.should_continue, receivers: result.receivers.map(receiver_raw => { 
+      console.log('receiver_raw: ' + receiver_raw);
+      return [
+      Array.from(receiver_raw[0].toU8a()),
+      this._encrypted_note_to_json(receiver_raw[1])
+    ];
+  }), senders: result.senders.map(sender_raw => { 
+    console.log('sender_raw: ' + sender_raw);
+    return Array.from(sender_raw.toU8a());}) };
+    console.log('result2: ' + result2);
+    return result2;
   }
 
   // Maps a transfer post object to its corresponding MantaPay extrinsic.

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -25,20 +25,18 @@ export default class Api {
   // Pulls data from the ledger from the `checkpoint` or later, returning the new checkpoint.
   async pull(checkpoint) {
     await this.api.isReady;
-    console.log(checkpoint);
+    console.log('checkpoint', checkpoint);
     let result = await this.api.rpc.mantaPay.pull_ledger_diff(checkpoint);
-    console.log(result);
-    const result2 = { should_continue: result.should_continue, receivers: result.receivers.map(receiver_raw => { 
-      console.log('receiver_raw: ' + receiver_raw);
+    console.log('pull result', result);
+    const receivers = result.receivers.map(receiver_raw => { 
       return [
       Array.from(receiver_raw[0].toU8a()),
       this._encrypted_note_to_json(receiver_raw[1])
-    ];
-  }), senders: result.senders.map(sender_raw => { 
-    console.log('sender_raw: ' + sender_raw);
-    return Array.from(sender_raw.toU8a());}) };
-    console.log('result2: ' + result2);
-    return result2;
+    ]});
+    const senders = result.senders.map(sender_raw => { 
+      return Array.from(sender_raw.toU8a());
+    }); 
+    return { should_continue: result.should_continue, receivers: receivers, senders: senders };
   }
 
   // Maps a transfer post object to its corresponding MantaPay extrinsic.

--- a/wallet/api/package.json
+++ b/wallet/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet-api",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "main": "./index.js",
     "private": false
 }

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -35,7 +35,7 @@ manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", defa
 manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
 manta-pay = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["groth16", "http", "scale", "serde"] }
 manta-util = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
-scale-codec = { package = "parity-scale-codec", version = "2.3.1", optional = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"] }
 serde_json = { version = "1.0.79", default-features = false, features = ["alloc", "arbitrary_precision"] }
 wasm-bindgen = { version = "0.2.79", default-features = false, features = ["serde-serialize", "std"] }
 wasm-bindgen-futures = { version = "0.4.29", default-features = false }

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -33,8 +33,9 @@ console_error_panic_hook = { version = "0.1.7", default-features = false }
 js-sys = { version = "0.3.56", default-features = false }
 manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
 manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
-manta-pay = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["groth16", "http", "serde"] }
+manta-pay = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["groth16", "http", "scale", "serde"] }
 manta-util = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
+scale-codec = { package = "parity-scale-codec", version = "2.3.1", optional = true, default-features = false, features = ["derive", "max-encoded-len"] }
 serde_json = { version = "1.0.79", default-features = false, features = ["alloc", "arbitrary_precision"] }
 wasm-bindgen = { version = "0.2.79", default-features = false, features = ["serde-serialize", "std"] }
 wasm-bindgen-futures = { version = "0.4.29", default-features = false }

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -35,7 +35,7 @@ manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", defa
 manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
 manta-pay = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["groth16", "http", "scale", "serde"] }
 manta-util = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["serde"] }
-scale-codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive", "max-encoded-len"] }
 serde_json = { version = "1.0.79", default-features = false, features = ["alloc", "arbitrary_precision"] }
 wasm-bindgen = { version = "0.2.79", default-features = false, features = ["serde-serialize", "std"] }
 wasm-bindgen-futures = { version = "0.4.29", default-features = false }

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-wasm-wallet"
 edition = "2021"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/crate/src/lib.rs
+++ b/wallet/crate/src/lib.rs
@@ -423,10 +423,6 @@ impl ledger::Read<SyncData<Config>> for PolkadotJsLedger {
     ) -> LocalBoxFutureResult<'s, ReadResponse<SyncData<Config>>, Self::Error>
     {
         Box::pin(async {
-            // let debug1 = self.0.pull(borrow_js(checkpoint)).await;
-            // panic!("debug1: {:?}, {:?}", debug1, debug1.as_string());
-            // let debug2 = from_js::<RawPullResponse>(self.0.pull(borrow_js(checkpoint)).await);
-            // panic!("debug2: {:?}", debug2);
             Ok(
                 from_js::<RawPullResponse>(self.0.pull(borrow_js(checkpoint)).await)
                     .try_into()

--- a/wallet/crate/src/lib.rs
+++ b/wallet/crate/src/lib.rs
@@ -326,10 +326,13 @@ impl PolkadotJsLedger {
 #[wasm_bindgen]
 pub struct LedgerError;
 
-impl ledger::Connection<Config> for PolkadotJsLedger {
+impl ledger::PullConfiguration<Config> for PolkadotJsLedger {
     type Checkpoint = Checkpoint;
     type ReceiverChunk = Vec<(Utxo, EncryptedNote)>;
     type SenderChunk = Vec<VoidNumber>;
+}
+
+impl ledger::Connection<Config> for PolkadotJsLedger {
     type PushResponse = String;
     type Error = LedgerError;
 
@@ -338,7 +341,8 @@ impl ledger::Connection<Config> for PolkadotJsLedger {
         &'s mut self,
         checkpoint: &'s Self::Checkpoint,
     ) -> LocalBoxFutureResult<'s, PullResponse<Config, Self>, Self::Error> {
-        Box::pin(async { from_js(self.0.pull(borrow_js(checkpoint)).await) })
+        // TODO: Box::pin(async { from_js(self.0.pull(borrow_js(checkpoint)).await) })
+        todo!()
     }
 
     #[inline]
@@ -415,8 +419,8 @@ impl Wallet {
 
     /// Returns the current balance associated with this `id`.
     #[inline]
-    pub fn balance(&self, id: AssetId) -> JsValue {
-        into_js(self.0.borrow().balance(id.into()))
+    pub fn balance(&self, id: AssetId) -> String {
+        self.0.borrow().balance(id.into()).to_string()
     }
 
     /// Returns true if `self` contains at least `asset.value` of the asset of kind `asset.id`.

--- a/wallet/crate/src/lib.rs
+++ b/wallet/crate/src/lib.rs
@@ -531,19 +531,7 @@ impl Wallet {
     pub fn checkpoint(&self) -> JsValue {
         borrow_js(self.0.borrow().checkpoint())
     }
-/*
-    /// Resets `self` to the default checkpoint and no balance. A call to this method should be
-    /// followed by a call to [`sync`](Self::sync) to retrieve the correct checkpoint and balance.
-    ///
-    /// # Note
-    ///
-    /// This is not a "full wallet recovery" which would involve resetting the signer as well as
-    /// this wallet state. See the [`recover`](Self::recover) method for more.
-    #[inline]
-    pub fn reset(&mut self) {
-        self.0.borrow_mut().reset()
-    }
-*/
+
     /// Calls `f` on a mutably borrowed value of `self` converting the future into a JS [`Promise`].
     #[allow(clippy::await_holding_refcell_ref)] // NOTE: JS is single-threaded so we can't panic.
     #[inline]

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./crate/pkg",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Replaces the manual `pull` command infrastructure with an RPC call to the node which computes the diff of the wallet state.