### PR TITLE
fix block hash query

### DIFF
--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -106,7 +106,7 @@ export default class Api {
     await this.api.isReady;
     const new_checkpoint = JSON.parse(JSON.stringify(checkpoint))
 
-    const block_hash = await api.rpc.chain.getBlockHash()
+    const block_hash = await this.api.rpc.chain.getBlockHash()
 
     // NOTE: The receiver indices represent the indices into the sharded utxo set. The utxos and
     //       encrypted notes should be pulled from the `Shards` storage structure. For each

--- a/wallet/api/package.json
+++ b/wallet/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet-api",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "./index.js",
     "private": false
 }


### PR DESCRIPTION
block hash query during wallet sync fails because `api` is undefined, need `this.api`