### PR TITLE
use old pull method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-sdk"
 edition = "2021"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -83,8 +83,16 @@ export default class Api {
     }
   }
 
+  stringToInt = (str) => {
+    return parseInt(str.replace(',', ''))
+  }
+
+  storageKeyToInt = (key) => {
+    this.stringToInt(key.toHuman()[0])
+  }
+
   _sort_senders = (a, b) => {
-    return parseInt(a[0].toHuman()) > parseInt(b[0].toHuman()) ? 1 : -1
+    return this.storageKeyToInt(a[0]) > this.storageKeyToInt(b[0]) ? 1 : -1
   }
 
   // Pulls sender data starting from `checkpoint`.
@@ -100,8 +108,8 @@ export default class Api {
   }
 
   _sort_receivers = (a, b) => {
-    const [a_shard_index, a_receiver_index] = a[0].toHuman().map(num => parseInt(num));
-    const [b_shard_index, b_receiver_index] = b[0].toHuman().map(num => parseInt(num));
+    const [a_shard_index, a_receiver_index] = a[0].toHuman().map(string => this.stringToInt(string));
+    const [b_shard_index, b_receiver_index] = b[0].toHuman().map(string => this.stringToInt(string));
     if (a_shard_index > b_shard_index) {
       return 1
     } else if (a_shard_index === b_shard_index && a_receiver_index > b_receiver_index) {
@@ -148,7 +156,6 @@ export default class Api {
       new_checkpoint.receiver_index = Object.values(new_checkpoint.receiver_index);
       return {
           should_continue: false,
-          next_checkpoint: new_checkpoint,
           receivers: receivers,
           senders: senders
       };

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -88,7 +88,7 @@ export default class Api {
   }
 
   storageKeyToInt = (key) => {
-    this.stringToInt(key.toHuman()[0])
+    return this.stringToInt(key.toHuman()[0])
   }
 
   _sort_senders = (a, b) => {

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -17,27 +17,28 @@ export default class Api {
   // Converts an `encrypted_note` into a JSON object.
   _encrypted_note_to_json(encrypted_note) {
     return  {
-        ephemeral_public_key: Array.from(encrypted_note.ephemeral_public_key.toU8a()),
+        ephemeral_public_key: Array.from(encrypted_note.ephemeralPublicKey.toU8a()),
         ciphertext: Array.from(encrypted_note.ciphertext.toU8a()),
     }
   }
 
+
   // Pulls data from the ledger from the `checkpoint` or later, returning the new checkpoint.
-  async pull(checkpoint) {
-    await this.api.isReady;
-    console.log('checkpoint', checkpoint);
-    let result = await this.api.rpc.mantaPay.pull_ledger_diff(checkpoint);
-    console.log('pull result', result);
-    const receivers = result.receivers.map(receiver_raw => { 
-      return [
-      Array.from(receiver_raw[0].toU8a()),
-      this._encrypted_note_to_json(receiver_raw[1])
-    ]});
-    const senders = result.senders.map(sender_raw => { 
-      return Array.from(sender_raw.toU8a());
-    }); 
-    return { should_continue: result.should_continue, receivers: receivers, senders: senders };
-  }
+  // async pull(checkpoint) {
+  //   await this.api.isReady;
+  //   console.log('checkpoint', checkpoint);
+  //   let result = await this.api.rpc.mantaPay.pull_ledger_diff(checkpoint);
+  //   console.log('pull result', result);
+  //   const receivers = result.receivers.map(receiver_raw => {
+  //     return [
+  //     Array.from(receiver_raw[0].toU8a()),
+  //     this._encrypted_note_to_json(receiver_raw[1])
+  //   ]});
+  //   const senders = result.senders.map(sender_raw => {
+  //     return Array.from(sender_raw.toU8a());
+  //   });
+  //   return { should_continue: result.should_continue, receivers: receivers, senders: senders };
+  // }
 
   // Maps a transfer post object to its corresponding MantaPay extrinsic.
   async _map_post_to_transaction(post) {
@@ -81,6 +82,92 @@ export default class Api {
       return { Ok: FAILURE }
     }
   }
+
+  _sort_senders = (a, b) => {
+    return parseInt(a[0].toHuman()) > parseInt(b[0].toHuman()) ? 1 : -1
+  }
+
+  // Pulls sender data starting from `checkpoint`.
+  async _pull_senders(checkpoint, new_checkpoint, block_hash) {
+    const sender_index = checkpoint.sender_index;
+    const entries = await this.api.query.mantaPay.voidNumberSetInsertionOrder.entriesAt(block_hash);
+    const senders = entries
+      .sort(this._sort_senders)
+      .map((entry) => Array.from(entry[1].toU8a()))
+      .slice(sender_index);
+    new_checkpoint.sender_index = sender_index + senders.length;
+    return senders;
+  }
+
+  _sort_receivers = (a, b) => {
+    const [a_shard_index, a_receiver_index] = a[0].toHuman().map(num => parseInt(num));
+    const [b_shard_index, b_receiver_index] = b[0].toHuman().map(num => parseInt(num));
+    if (a_shard_index > b_shard_index) {
+      return 1
+    } else if (a_shard_index === b_shard_index && a_receiver_index > b_receiver_index) {
+      return 1
+    }
+    return -1
+  }
+
+  // Pulls receiver data starting from `checkpoint`.
+  async _pull_receivers(checkpoint, new_checkpoint, block_hash) {
+    const new_receivers = []
+    let entries_raw = await this.api.query.mantaPay.shards.entriesAt(block_hash)
+    entries_raw.sort(this._sort_receivers);
+    const entries = entries_raw.map(([storage_key, receiver_raw]) => {
+      let map_keys = storage_key.args.map((k) => k.toHuman())
+      let shard_index = parseInt(map_keys[0]);
+      let receiver_index = parseInt(map_keys[1]);
+      const receiver = [
+        Array.from(receiver_raw[0].toU8a()),
+        this._encrypted_note_to_json(receiver_raw[1])
+      ]
+      return [shard_index, receiver_index, receiver]
+    });
+
+    entries.forEach(([shard_index, receiver_index, receiver]) => {
+      if (receiver_index >= checkpoint.receiver_index[shard_index]) {
+        new_receivers.push(receiver);
+        if (receiver_index >= new_checkpoint.receiver_index[shard_index]) {
+          new_checkpoint.receiver_index[shard_index] = receiver_index + 1;
+        }
+      }
+    })
+
+    return new_receivers;
+  }
+
+    // Pulls data from the ledger from the `checkpoint` or later, returning the new checkpoint.
+    async pull(checkpoint) {
+      await this.api.isReady;
+      const new_checkpoint = JSON.parse(JSON.stringify(checkpoint))
+      const block_hash = await this.api.rpc.chain.getBlockHash()
+      const receivers = await this._pull_receivers(checkpoint, new_checkpoint, block_hash);
+      const senders = await this._pull_senders(checkpoint, new_checkpoint, block_hash);
+      new_checkpoint.receiver_index = Object.values(new_checkpoint.receiver_index);
+      return {
+          should_continue: false,
+          next_checkpoint: new_checkpoint,
+          receivers: receivers,
+          senders: senders
+      };
+    }
+
+    // Sign and send a single batch
+    async _push_batch(batch) {
+      console.log("[INFO] Batch: ", batch);
+      try {
+        const batchTx = await this.api.tx.utility.batch(batch);
+        console.log("[INFO] Batch Transaction: ", batchTx);
+        await batchTx.signAndSend(this.externalAccountSigner, this.txResHandler);
+        return true;
+      } catch (err) {
+        console.error(err);
+        return false;
+      }
+    }
+
 }
 
 export const SUCCESS = "success";

--- a/wallet/api/package.json
+++ b/wallet/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet-api",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "./index.js",
     "private": false
 }

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-wasm-wallet"
 edition = "2021"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "./crate/pkg",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Changes `manta-wasm-wallet-api` to fetch on chain data using polkadot.js `query` methods rather than the new `pull_ledger_diff` rpc, which isn't ready yet