### PR TITLE
Fix/tune pull size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-sdk"
 edition = "2021"
-version = "1.2.1"
+version = "1.3.1"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -1,11 +1,24 @@
 // Polkadot-JS Ledger Integration
 
 // Polkadot-JS Ledger API
-export default class Api {
-  // Constructs an API from a polkadot-js API.
-  constructor(api, externalAccountSigner) {
+
+export class ApiConfig {
+  constructor(api, externalAccountSigner, maxReceiversPullSize, maxSendersPullSize) {
     this.api = api;
     this.externalAccountSigner = externalAccountSigner;
+    this.maxReceiversPullSize = maxReceiversPullSize;
+    this.maxSendersPullSize = maxSendersPullSize;
+  }
+}
+
+export default class Api {
+  // Constructs an API from a config
+  constructor(config) {
+    this.config = config;
+    this.api = this.config.api;
+    this.externalAccountSigner = this.config.externalAccountSigner;
+    this.maxReceiversPullSize = this.config.maxReceiversPullSize;
+    this.maxSendersPullSize = this.config.maxSendersPullSize;
     this.txResHandler = null;
   }
 
@@ -27,7 +40,11 @@ export default class Api {
   async pull(checkpoint) {
     await this.api.isReady;
     console.log('checkpoint', checkpoint);
-    let result = await this.api.rpc.mantaPay.pull_ledger_diff(checkpoint, MAX_RECEIVERS, MAX_SENDERS);
+    let result = await this.api.rpc.mantaPay.pull_ledger_diff(
+      checkpoint,
+      this.maxReceiversPullSize,
+      this.maxSendersPullSize
+    );
     console.log('pull result', result);
     const receivers = result.receivers.map(receiver_raw => {
       return [
@@ -84,7 +101,5 @@ export default class Api {
   }
 }
 
-const MAX_RECEIVERS = 4096;
-const MAX_SENDERS = 4096;
 export const SUCCESS = 'success';
 export const FAILURE = 'failure';

--- a/wallet/api/index.js
+++ b/wallet/api/index.js
@@ -17,9 +17,9 @@ export default class Api {
   // Converts an `encrypted_note` into a JSON object.
   _encrypted_note_to_json(encrypted_note) {
     return  {
-        ephemeral_public_key: Array.from(encrypted_note.ephemeral_public_key.toU8a()),
-        ciphertext: Array.from(encrypted_note.ciphertext.toU8a()),
-    }
+      ephemeral_public_key: Array.from(encrypted_note.ephemeral_public_key.toU8a()),
+      ciphertext: Array.from(encrypted_note.ciphertext.toU8a()),
+    };
   }
 
 
@@ -31,9 +31,9 @@ export default class Api {
     console.log('pull result', result);
     const receivers = result.receivers.map(receiver_raw => {
       return [
-      Array.from(receiver_raw[0].toU8a()),
-      this._encrypted_note_to_json(receiver_raw[1])
-    ]});
+        Array.from(receiver_raw[0].toU8a()),
+        this._encrypted_note_to_json(receiver_raw[1])
+      ];});
     const senders = result.senders.map(sender_raw => {
       return Array.from(sender_raw.toU8a());
     });
@@ -74,17 +74,17 @@ export default class Api {
     }
     try {
       const batchTx = await this.api.tx.utility.batch(transactions);
-      console.log("[INFO] Batch Transaction:", batchTx);
-      console.log("[INFO] Result:", await batchTx.signAndSend(this.externalAccountSigner, this.txResHandler));
+      console.log('[INFO] Batch Transaction:', batchTx);
+      console.log('[INFO] Result:', await batchTx.signAndSend(this.externalAccountSigner, this.txResHandler));
       return { Ok: SUCCESS };
     } catch(err) {
       console.error(err);
-      return { Ok: FAILURE }
+      return { Ok: FAILURE };
     }
   }
 }
 
-const MAX_RECEIVERS = 32768;
-const MAX_SENDERS = 32768;
-export const SUCCESS = "success";
-export const FAILURE = "failure";
+const MAX_RECEIVERS = 4096;
+const MAX_SENDERS = 4096;
+export const SUCCESS = 'success';
+export const FAILURE = 'failure';

--- a/wallet/api/package.json
+++ b/wallet/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet-api",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "./index.js",
     "private": false
 }

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-wasm-wallet"
 edition = "2021"
-version = "1.3.1-dev"
+version = "1.3.1"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-wasm-wallet"
 edition = "2021"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/crate/Cargo.toml
+++ b/wallet/crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-wasm-wallet"
 edition = "2021"
-version = "1.3.1"
+version = "1.3.1-dev"
 authors = ["Manta Network <contact@manta.network>"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-wasm-wallet",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "./crate/pkg",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
makes pull size configurable when initializing the manta wasm wallet API; the previous pull size was too big and caused pulls to timeout