### PR TITLE
Return 3 bytes less for xcm remote transact payload

### DIFF
--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -5,10 +5,10 @@ import { web3Accounts, web3Enable, web3FromSource } from '@polkadot/extension-da
 
 async function main() {
     await toPrivateOnlySignTest();
-    await toPrivateTest();
-    await privateTransferTest();
-    await toPublicTest();
-    await publicTransferTest();
+    // await toPrivateTest();
+    // await privateTransferTest();
+    // await toPublicTest();
+    // await publicTransferTest();
     console.log("END");
 }
 
@@ -106,7 +106,7 @@ const privateTransferTest = async () => {
 const toPrivateOnlySignTest = async () => {
 
     const privateWalletConfig = {
-        environment: Environment.Development,
+        environment: Environment.Production,
         network: Network.Dolphin
     }
 
@@ -128,8 +128,9 @@ const toPrivateOnlySignTest = async () => {
 
     console.log("The result of the signing: ", signResult);
 
+    console.log("Full: ", JSON.stringify(signResult.txs));
     // remove first 3 bytes of the signResult
-    console.log("For xcm remote transact payload, please use: \"0x" + JSON.stringify(signResult.txs).slice(10));
+    console.log("For xcm remote transact payload, please use: [\"0x" + JSON.stringify(signResult.txs).slice(10));
 }
 
 /// Test to execute a `ToPrivate` transaction.

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -5,10 +5,10 @@ import { web3Accounts, web3Enable, web3FromSource } from '@polkadot/extension-da
 
 async function main() {
     await toPrivateOnlySignTest();
-    // await toPrivateTest();
-    // await privateTransferTest();
-    // await toPublicTest();
-    // await publicTransferTest();
+    await toPrivateTest();
+    await privateTransferTest();
+    await toPublicTest();
+    await publicTransferTest();
     console.log("END");
 }
 

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -124,9 +124,12 @@ const toPrivateOnlySignTest = async () => {
     const initalPrivateBalance = await privateWallet.getPrivateBalance(assetId);
     console.log("The inital private balance is: ", initalPrivateBalance.toString());
 
-    const signResult = await privateWallet.toPrivateSend(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
+    const signResult = await privateWallet.toPrivateBuild(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 
-    console.log("The result of the signing: ", signResult);
+    console.log("The result of the signing: \"0x", JSON.stringify(signResult));
+
+    // remove first 3 bytes of the signResult
+    console.log("For xcm remote transact payload, please use: \"0x" + JSON.stringify(signResult.txs).slice(10));
 }
 
 /// Test to execute a `ToPrivate` transaction.

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -126,7 +126,7 @@ const toPrivateOnlySignTest = async () => {
 
     const signResult = await privateWallet.toPrivateBuild(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 
-    console.log("The result of the signing: ", JSON.stringify(signResult));
+    console.log("The result of the signing: ", signResult);
 
     // remove first 3 bytes of the signResult
     console.log("For xcm remote transact payload, please use: \"0x" + JSON.stringify(signResult.txs).slice(10));

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -55,8 +55,8 @@ const publicTransferTest = async () => {
 
     await new Promise(r => setTimeout(r, 10000));
 
-    const senderBalanceAfterTrasnfer = await MantaUtilities.getPublicBalance(privateWallet.api, assetId,polkadotConfig.polkadotAddress);
-    console.log("Sender Balance After:" + JSON.stringify(senderBalanceAfterTrasnfer.toString()));
+    const senderBalanceAfterTransfer = await MantaUtilities.getPublicBalance(privateWallet.api, assetId,polkadotConfig.polkadotAddress);
+    console.log("Sender Balance After:" + JSON.stringify(senderBalanceAfterTransfer.toString()));
 
     const destinationBalanceAfterTransfer = await MantaUtilities.getPublicBalance(privateWallet.api, assetId, destinationAddress);
     console.log("Dest Balance After:" + JSON.stringify(destinationBalanceAfterTransfer.toString()));
@@ -79,8 +79,8 @@ const privateTransferTest = async () => {
 
     await privateWallet.initalWalletSync();
 
-    const initalPrivateBalance = await privateWallet.getPrivateBalance(assetId);
-    console.log("The inital private balance is: ", initalPrivateBalance.toString());
+    const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
+    console.log("The initial private balance is: ", initialPrivateBalance.toString());
 
     await privateWallet.privateTransferSend(assetId, amount, toPrivateTestAddress, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 
@@ -92,9 +92,9 @@ const privateTransferTest = async () => {
         let newPrivateBalance = await privateWallet.getPrivateBalance(assetId);
         console.log("Private Balance after sync: ", newPrivateBalance.toString());
 
-        if (initalPrivateBalance !== newPrivateBalance) {
+        if (initialPrivateBalance !== newPrivateBalance) {
             console.log("Detected balance change after sync!");
-            console.log("Old balance: ", initalPrivateBalance.toString());
+            console.log("Old balance: ", initialPrivateBalance.toString());
             console.log("New balance: ", newPrivateBalance.toString());
             break;
         }
@@ -121,12 +121,12 @@ const toPrivateOnlySignTest = async () => {
 
     await privateWallet.initalWalletSync();
 
-    const initalPrivateBalance = await privateWallet.getPrivateBalance(assetId);
-    console.log("The inital private balance is: ", initalPrivateBalance.toString());
+    const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
+    console.log("The initial private balance is: ", initialPrivateBalance.toString());
 
     const signResult = await privateWallet.toPrivateBuild(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 
-    console.log("The result of the signing: \"0x", JSON.stringify(signResult));
+    console.log("The result of the signing: ", JSON.stringify(signResult));
 
     // remove first 3 bytes of the signResult
     console.log("For xcm remote transact payload, please use: \"0x" + JSON.stringify(signResult.txs).slice(10));
@@ -153,8 +153,8 @@ const toPrivateTest = async () => {
 
     await privateWallet.initalWalletSync();
 
-    const initalPrivateBalance = await privateWallet.getPrivateBalance(assetId);
-    console.log("The inital private balance is: ", initalPrivateBalance.toString());
+    const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
+    console.log("The initial private balance is: ", initialPrivateBalance.toString());
 
     await privateWallet.toPrivateSend(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 
@@ -166,9 +166,9 @@ const toPrivateTest = async () => {
         let newPrivateBalance = await privateWallet.getPrivateBalance(assetId);
         console.log("Private Balance after sync: ", newPrivateBalance.toString());
 
-        if (initalPrivateBalance !== newPrivateBalance) {
+        if (initialPrivateBalance !== newPrivateBalance) {
             console.log("Detected balance change after sync!");
-            console.log("Old balance: ", initalPrivateBalance.toString());
+            console.log("Old balance: ", initialPrivateBalance.toString());
             console.log("New balance: ", newPrivateBalance.toString());
             break;
         }
@@ -195,8 +195,8 @@ const toPublicTest = async () => {
 
     await privateWallet.initalWalletSync();
 
-    const initalPrivateBalance = await privateWallet.getPrivateBalance(assetId);
-    console.log("The inital private balance is: ", initalPrivateBalance.toString());
+    const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
+    console.log("The inital private balance is: ", initialPrivateBalance.toString());
 
     await privateWallet.toPublicSend(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

For payloads that will be used in XCM messages, the first 3 bytes of the sign result will cause the decoding errors, so need to just remove them before returning to user.

closes #69 