### PR TITLE
init private wallet without connected api

### DIFF
--- a/manta-js/CHANGELOG.md
+++ b/manta-js/CHANGELOG.md
@@ -21,3 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [\#51](https://github.com/Manta-Network/manta-signer/pull/51) Initial version of manta.js
+
+
+## [2.0.0] 2022-2-24
+
+### Changed
+- [\#86](https://github.com/Manta-Network/manta-signer/pull/86) Allow the PrivateWallet class to be initialized without polkadot.js api being connected to a node

--- a/manta-js/README.md
+++ b/manta-js/README.md
@@ -71,6 +71,7 @@ const privateWalletConfig: PrivateWalletConfig = {
 };
 
 const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+await privateWallet.api.isReady;
 ```
 
 `PrivateWalletConfig` has several optional arguments:

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -38,6 +38,7 @@ const publicTransferTest = async () => {
     }
 
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+    await privateWallet.api.isReady;
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
     const assetId = new BN("1"); // DOL
@@ -70,6 +71,7 @@ const privateTransferTest = async () => {
     }
 
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+    await privateWallet.api.isReady;
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
     const assetId = new BN("1"); // DOL
@@ -111,6 +113,7 @@ const toPrivateOnlySignTest = async () => {
     }
 
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+    await privateWallet.api.isReady;
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
     const privateAddress = await privateWallet.getZkAddress();
@@ -144,6 +147,7 @@ const toPrivateTest = async () => {
     }
 
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+    await privateWallet.api.isReady;
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
     const privateAddress = await privateWallet.getZkAddress();
@@ -186,6 +190,7 @@ const toPublicTest = async () => {
     }
 
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+    await privateWallet.api.isReady;
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
     const privateAddress = await privateWallet.getZkAddress();

--- a/manta-js/package/package.json
+++ b/manta-js/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta.js",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "manta.js sdk",
   "main": "./dist/browser/index.js",
   "exports": {

--- a/manta-js/package/src/privateWallet.ts
+++ b/manta-js/package/src/privateWallet.ts
@@ -131,9 +131,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Requirements: Must be called once after creating an instance of MantaPrivateWallet
   /// and must be called before walletSync().
   async initalWalletSync(): Promise<boolean> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -157,9 +155,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// balance state. This method runs until all the ledger data has arrived at and
   /// has been synchronized with the wallet.
   async walletSync(): Promise<boolean> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     try {
       if (!this.initialSyncIsFinished) {
         throw new Error('Must call initalWalletSync before walletSync!');
@@ -184,9 +180,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Returns the private balance of the currently connected zkAddress for the currently
   /// connected network.
   async getPrivateBalance(assetId: BN): Promise<BN | null> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -204,9 +198,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Returns the metadata for an asset with a given `assetId` for the currently
   /// connected network.
   async getAssetMetadata(assetId: BN): Promise<any> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     const data: any = await this.api.query.assetManager.assetIdMetadata(assetId);
     const json = JSON.stringify(data.toHuman());
     const jsonObj = JSON.parse(json);
@@ -221,9 +213,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Executes a "To Private" transaction for any fungible token.
   async toPrivateSend(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<void> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     const signed = await this.toPrivateBuild(assetId,amount,polkadotSigner, polkadotAddress);
     // transaction rejected by signer
     if (signed === null) {
@@ -236,9 +226,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Builds and signs a "To Private" transaction for any fungible token.
   /// Note: This transaction is not published to the ledger.
   async toPrivateBuild(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -256,9 +244,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Executes a "Private Transfer" transaction for any fungible token.
   async privateTransferSend(assetId: BN, amount: BN, toPrivateAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<void> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     const signed = await this.privateTransferBuild(assetId,amount,toPrivateAddress,polkadotSigner,polkadotAddress);
     // transaction rejected by signer
     if (signed === null) {
@@ -271,9 +257,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Builds a "Private Transfer" transaction for any fungible token.
   /// Note: This transaction is not published to the ledger.
   async privateTransferBuild(assetId: BN, amount: BN, toPrivateAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -291,9 +275,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Executes a "To Public" transaction for any fungible token.
   async toPublicSend(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<void> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     const signed = await this.toPublicBuild(assetId,amount,polkadotSigner, polkadotAddress);
     // transaction rejected by signer
     if (signed === null) {
@@ -306,9 +288,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Builds and signs a "To Public" transaction for any fungible token.
   /// Note: This transaction is not published to the ledger.
   async toPublicBuild(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null> {
-    if (!this.api.isReady) {
-      throw new Error('Polkadot.js API is not ready.');
-    }
+    this.checkApiIsReady();
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -363,6 +343,12 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
     }
 
     return { api };
+  }
+
+  private checkApiIsReady(): void {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
   }
 
   /// Private helper method for internal use to initialize the initialize manta-wasm-wallet.

--- a/manta-js/package/src/privateWallet.ts
+++ b/manta-js/package/src/privateWallet.ts
@@ -59,9 +59,18 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Initializes the MantaPrivateWallet class, for a corresponding environment and network.
   static async init(config: PrivateWalletConfig): Promise<MantaPrivateWallet> {
-    const { api } = await MantaPrivateWallet.initApi(config.environment, config.network, Boolean(config.loggingEnabled));
+    const { api } = MantaPrivateWallet.initApi(
+      config.environment, config.network, Boolean(config.loggingEnabled)
+    );
     const { wasm, wasmWallet, wasmApi } = await MantaPrivateWallet.initWasmSdk(api,config);
-    return new MantaPrivateWallet(api,wasm,wasmWallet,config.network,wasmApi,Boolean(config.loggingEnabled));
+    return new MantaPrivateWallet(
+      api,
+      wasm,
+      wasmWallet,
+      config.network,
+      wasmApi,
+      Boolean(config.loggingEnabled)
+    );
   }
 
   /// Convert a private address to JSON.
@@ -122,6 +131,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Requirements: Must be called once after creating an instance of MantaPrivateWallet
   /// and must be called before walletSync().
   async initalWalletSync(): Promise<boolean> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -145,6 +157,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// balance state. This method runs until all the ledger data has arrived at and
   /// has been synchronized with the wallet.
   async walletSync(): Promise<boolean> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     try {
       if (!this.initialSyncIsFinished) {
         throw new Error('Must call initalWalletSync before walletSync!');
@@ -169,6 +184,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Returns the private balance of the currently connected zkAddress for the currently
   /// connected network.
   async getPrivateBalance(assetId: BN): Promise<BN | null> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -186,6 +204,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Returns the metadata for an asset with a given `assetId` for the currently
   /// connected network.
   async getAssetMetadata(assetId: BN): Promise<any> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     const data: any = await this.api.query.assetManager.assetIdMetadata(assetId);
     const json = JSON.stringify(data.toHuman());
     const jsonObj = JSON.parse(json);
@@ -200,6 +221,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Executes a "To Private" transaction for any fungible token.
   async toPrivateSend(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<void> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     const signed = await this.toPrivateBuild(assetId,amount,polkadotSigner, polkadotAddress);
     // transaction rejected by signer
     if (signed === null) {
@@ -212,6 +236,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Builds and signs a "To Private" transaction for any fungible token.
   /// Note: This transaction is not published to the ledger.
   async toPrivateBuild(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -229,6 +256,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Executes a "Private Transfer" transaction for any fungible token.
   async privateTransferSend(assetId: BN, amount: BN, toPrivateAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<void> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     const signed = await this.privateTransferBuild(assetId,amount,toPrivateAddress,polkadotSigner,polkadotAddress);
     // transaction rejected by signer
     if (signed === null) {
@@ -241,6 +271,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Builds a "Private Transfer" transaction for any fungible token.
   /// Note: This transaction is not published to the ledger.
   async privateTransferBuild(assetId: BN, amount: BN, toPrivateAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -258,6 +291,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
 
   /// Executes a "To Public" transaction for any fungible token.
   async toPublicSend(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<void> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     const signed = await this.toPublicBuild(assetId,amount,polkadotSigner, polkadotAddress);
     // transaction rejected by signer
     if (signed === null) {
@@ -270,6 +306,9 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   /// Builds and signs a "To Public" transaction for any fungible token.
   /// Note: This transaction is not published to the ledger.
   async toPublicBuild(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null> {
+    if (!this.api.isReady) {
+      throw new Error('Polkadot.js API is not ready.');
+    }
     try {
       await this.waitForWallet();
       this.walletIsBusy = true;
@@ -306,22 +345,24 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
   }
 
   /// Private helper method for internal use to initialize the Polkadot.js API with web3Extension.
-  private static async initApi(env: Environment, network: Network, loggingEnabled:boolean): Promise<InitApiResult> {
+  private static initApi(env: Environment, network: Network, loggingEnabled: boolean): InitApiResult {
     const provider = new WsProvider(MantaPrivateWallet.envUrl(env, network));
-    const api = await ApiPromise.create({ provider, types, rpc });
-    const [chain, nodeName, nodeVersion] = await Promise.all([
-      api.rpc.system.chain(),
-      api.rpc.system.name(),
-      api.rpc.system.version()
-    ]);
+    const api = new ApiPromise({ provider, types, rpc });
 
     if (loggingEnabled) {
-      console.log(`[INFO]: MantaPrivateWallet is connected to chain ${chain} using ${nodeName} v${nodeVersion}`);
+      api.isReady.then(async () => {
+        const [chain, nodeName, nodeVersion] = await Promise.all([
+          api.rpc.system.chain(),
+          api.rpc.system.name(),
+          api.rpc.system.version()
+        ]);
+        console.log(
+          `[INFO]: MantaPrivateWallet api is connected to chain ${chain} using`
+          + `${nodeName} v${nodeVersion}`);
+      });
     }
 
-    return {
-      api
-    };
+    return { api };
   }
 
   /// Private helper method for internal use to initialize the initialize manta-wasm-wallet.


### PR DESCRIPTION
closes #74 

When calling `init` on `PrivateWallet`, we no longer wait for polkadot.js to successfully connect to a node. This way, it is possible to use `PrivateWallet` to get a zkAddress from Manta Signer even if a node connection is not available. This means that code must `await privateWallet.api.isReady` before calling methods that require connection to a node.

There are probably better long term solutions, but this solution is quite low effort and fixes a bad front end pain point. In the future, we may (for example) want to spin off a standalone utility function to get the zkAddress from Manta Signer, without the `PrivateWallet` class.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/sdk/blob/main/CHANGELOG.md) and added the appropriate `L-` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.

