### PR TITLE
Change all occurrences of private address to zkAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#71](https://github.com/Manta-Network/sdk/pull/71) Update to dense pull ledger diff
 
 ### Changed
+- [\#88](https://github.com/Manta-Network/sdk/pull/88) Update API wording to be consistent with company-wide language.
 
 ### Deprecated
 

--- a/manta-js/README.md
+++ b/manta-js/README.md
@@ -83,7 +83,7 @@ const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
 
 ## Transacting
 
-After initialization of the `MantaPrivateWallet` class, `initalWalletSync()` must be called before any transactions are made.
+After initialization of the `MantaPrivateWallet` class, `initialWalletSync()` must be called before any transactions are made.
 
 After every single transaction, to get the latest data from the ledger, `walletSync()` must be called.
 
@@ -133,10 +133,10 @@ const amount = new BN("10000000000000000000");
 // Sync with most recent ledger state.
 await privateWallet.initialWalletSync();
 
-// Get private address
-const privateAddress = await privateWallet.getPrivateAddress();
+// Get zk address
+const zkAddress = await privateWallet.getZkAddress();
 
-// Get private balance of DOL for given private address
+// Get private balance of DOL for given zk address
 const privateBalance = await privateWallet.getPrivateBalance(assetId);
 
 // Privatize 10 DOL to 10 pDOL
@@ -161,12 +161,12 @@ const amount = new BN("10000000000000000000");
 // Sync with most recent ledger state.
 await privateWallet.initialWalletSync();
 
-// Get private address
-const privateAddress = await privateWallet.getPrivateAddress();
+// Get zk address
+const zkAddress = await privateWallet.getZkAddress();
 
-// Private Transfer of 10 pDOL to another private address
-const examplePrivateAddress = "3UG1BBvv7viqwyg1QKsMVarnSPcdiRQ1aL2vnTgwjWYX";
-await privateWallet.privateTransferSend(assetId, amount, examplePrivateAddress, polkadotSigner, polkadotAddress);
+// Private Transfer of 10 pDOL to another zk address
+const exampleZkAddress = "3UG1BBvv7viqwyg1QKsMVarnSPcdiRQ1aL2vnTgwjWYX";
+await privateWallet.privateTransferSend(assetId, amount, exampleZkAddress, polkadotSigner, polkadotAddress);
 
 // Sync to get latest data after transaction and check that it was successful.
 await privateWallet.walletSync();
@@ -187,10 +187,10 @@ const amount = new BN("5000000000000000000");
 // Sync with most recent ledger state.
 await privateWallet.initialWalletSync();
 
-// Get private address
-const privateAddress = await privateWallet.getPrivateAddress();
+// Get zk address
+const zkAddress = await privateWallet.getZkAddress();
 
-// Get private balance of DOL for given private address
+// Get private balance of DOL for given zk address
 const privateBalance = await privateWallet.getPrivateBalance(assetId);
 
 // Convert 5 pDOL back to DOL
@@ -242,13 +242,13 @@ const env = sdk.Environment.Development;
 const net = sdk.Network.Dolphin;
 const privateWallet = await sdk.init(env,net);
 
-const privateAddress = await privateWallet.privateAddress();
-console.log("The private address is: ", privateAddress);
+const zkAddress = await privateWallet.getZkAddress();
+console.log("The zk address is: ", zkAddress);
 
-await privateWallet.initalWalletSync();
+await privateWallet.initialWalletSync();
 
-const initalPrivateBalance = await privateWallet.privateBalance(assetId);
-console.log("The inital private balance is: ", initalPrivateBalance.toString());
+const initialPrivateBalance = await privateWallet.privateBalance(assetId);
+console.log("The initial private balance is: ", initialPrivateBalance.toString());
 
 const signResult = await privateWallet.toPrivateBuild(assetId, amount, polkadotSigner, polkadotAddress);
 
@@ -260,7 +260,7 @@ This can also be done for all other transaction types:
 ```javascript
 const toPrivateSignResult = await privateWallet.toPrivateBuild(assetId, amount, polkadotSigner, polkadotAddress);
 const toPublicSignResult = await privateWallet.toPublicBuild(assetId, amount, polkadotSigner, polkadotAddress);
-const privateTransferSignResult = await privateWallet.privateTransferBuild(assetId, amount, privateAddress, polkadotSigner, polkadotAddress);
+const privateTransferSignResult = await privateWallet.privateTransferBuild(assetId, amount, zkAddress, polkadotSigner, polkadotAddress);
 ```
 
 Then you can use the signResult to submit transaction by your self. Here is an example on how to verify the `toPrivateBuild` sign result is valid:

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -77,7 +77,7 @@ const privateTransferTest = async () => {
 
     const toPrivateTestAddress = "3UG1BBvv7viqwyg1QKsMVarnSPcdiRQ1aL2vnTgwjWYX";
 
-    await privateWallet.initalWalletSync();
+    await privateWallet.initialWalletSync();
 
     const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
     console.log("The initial private balance is: ", initialPrivateBalance.toString());
@@ -113,13 +113,13 @@ const toPrivateOnlySignTest = async () => {
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
-    const privateAddress = await privateWallet.getZkAddress();
-    console.log("The private address is: ", privateAddress);
+    const zkAddress = await privateWallet.getZkAddress();
+    console.log("The zk address is: ", zkAddress);
 
     const assetId = new BN("1"); // DOL
     const amount = new BN("10000000000000000000"); // 10 units
 
-    await privateWallet.initalWalletSync();
+    await privateWallet.initialWalletSync();
 
     const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
     console.log("The initial private balance is: ", initialPrivateBalance.toString());
@@ -146,13 +146,13 @@ const toPrivateTest = async () => {
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
-    const privateAddress = await privateWallet.getZkAddress();
-    console.log("The private address is: ", privateAddress);
+    const zkAddress = await privateWallet.getZkAddress();
+    console.log("The zk address is: ", zkAddress);
 
     const assetId = new BN("1"); // DOL
     const amount = new BN("10000000000000000000"); // 10 units
 
-    await privateWallet.initalWalletSync();
+    await privateWallet.initialWalletSync();
 
     const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
     console.log("The initial private balance is: ", initialPrivateBalance.toString());
@@ -188,16 +188,16 @@ const toPublicTest = async () => {
     const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
     const polkadotConfig = await getPolkadotSignerAndAddress();
 
-    const privateAddress = await privateWallet.getZkAddress();
-    console.log("The private address is: ", privateAddress);
+    const zkAddress = await privateWallet.getZkAddress();
+    console.log("The zk address is: ", zkAddress);
 
     const assetId = new BN("1"); // DOL
     const amount = new BN("5000000000000000000"); // 5 units
 
-    await privateWallet.initalWalletSync();
+    await privateWallet.initialWalletSync();
 
     const initialPrivateBalance = await privateWallet.getPrivateBalance(assetId);
-    console.log("The inital private balance is: ", initialPrivateBalance.toString());
+    console.log("The initial private balance is: ", initialPrivateBalance.toString());
 
     await privateWallet.toPublicSend(assetId, amount, polkadotConfig.polkadotSigner, polkadotConfig.polkadotAddress);
 

--- a/manta-js/package/src/privateWallet.ts
+++ b/manta-js/package/src/privateWallet.ts
@@ -94,7 +94,7 @@ export class MantaPrivateWallet implements IMantaPrivateWallet {
     return config.NETWORKS;
   }
 
-  /// Returns the ZkAddress (ZK Address) of the currently connected manta-signer instance.
+  /// Returns the ZkAddress of the currently connected manta-signer instance.
   async getZkAddress(): Promise<Address> {
     try {
       await this.waitForWallet();

--- a/manta-js/package/src/sdk.interfaces.ts
+++ b/manta-js/package/src/sdk.interfaces.ts
@@ -47,17 +47,17 @@ export interface IMantaPrivateWallet {
   initialSyncIsFinished: boolean;
   loggingEnabled: boolean;
 
-  convertPrivateAddressToJson(address: string): any
+  convertZkAddressToJson(address: string): any
   getNetworks(): any;
   getZkAddress(): Promise<Address>;
   getAssetMetadata(assetId: BN): Promise<any>;
-  initalWalletSync(): Promise<boolean>;
+  initialWalletSync(): Promise<boolean>;
   walletSync(): Promise<boolean>;
   getPrivateBalance(assetId: BN): Promise<BN | null>;
   toPrivateSend(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<void>;
   toPrivateBuild(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null>;
-  privateTransferSend(assetId: BN, amount: BN, toPrivateAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<void>;
-  privateTransferBuild(assetId: BN, amount: BN, toPrivateAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null>;
+  privateTransferSend(assetId: BN, amount: BN, zkAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<void>;
+  privateTransferBuild(assetId: BN, amount: BN, zkAddress: Address, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null>;
   toPublicSend(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<void>;
   toPublicBuild(assetId: BN, amount: BN, polkadotSigner:Signer, polkadotAddress:Address): Promise<SignedTransaction | null>;
 }


### PR DESCRIPTION
closes #87

* Change all occurences of privateAddress to zkAddress to keep it consistent with the company's language 
* Fix spelling mistake in `initalWlaletSync` -> `initialWalletSync`


---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/sdk/blob/main/CHANGELOG.md) and added the appropriate `L-` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.

