### PR TITLE
Add missing publicTransferBuild variant

### DIFF
--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -9,6 +9,7 @@ async function main() {
     await privateTransferTest();
     await toPublicTest();
     await publicTransferTest();
+    await publicTransferOnlySignTest();
     console.log("END");
 }
 
@@ -51,7 +52,7 @@ const publicTransferTest = async () => {
     const destinationBalance = await MantaUtilities.getPublicBalance(privateWallet.api, assetId, destinationAddress);
     console.log("Destination Balance:" + JSON.stringify(destinationBalance.toString()));
 
-    await MantaUtilities.publicTransfer(privateWallet.api, assetId, amount, destinationAddress, polkadotConfig.polkadotAddress, polkadotConfig.polkadotSigner);
+    await MantaUtilities.publicTransferSend(privateWallet.api, assetId, amount, destinationAddress, polkadotConfig.polkadotAddress, polkadotConfig.polkadotSigner);
 
     await new Promise(r => setTimeout(r, 10000));
 
@@ -60,6 +61,24 @@ const publicTransferTest = async () => {
 
     const destinationBalanceAfterTransfer = await MantaUtilities.getPublicBalance(privateWallet.api, assetId, destinationAddress);
     console.log("Dest Balance After:" + JSON.stringify(destinationBalanceAfterTransfer.toString()));
+}
+
+const publicTransferOnlySignTest = async () => {
+
+    const privateWalletConfig = {
+        environment: Environment.Production,
+        network: Network.Dolphin
+    }
+
+    const privateWallet = await MantaPrivateWallet.init(privateWalletConfig);
+
+    const destinationAddress = "5FHT5Rt1oeqAytX5KSn4ZZQdqN8oEa5Y81LZ5jadpk41bdoM";
+    const assetId = new BN("1"); // DOL
+    const amount = new BN("10000000000000000000"); // 10 units
+
+    let tx = MantaUtilities.publicTransferBuild(privateWallet.api, assetId, amount, destinationAddress);
+
+    console.log("The resulting tx payload is : ", tx);
 }
 
 /// Test to privately transfer 5 pDOL.

--- a/manta-js/examples/asset-webpack-ts/index.ts
+++ b/manta-js/examples/asset-webpack-ts/index.ts
@@ -74,7 +74,7 @@ const publicTransferOnlySignTest = async () => {
 
     const destinationAddress = "5FHT5Rt1oeqAytX5KSn4ZZQdqN8oEa5Y81LZ5jadpk41bdoM";
     const assetId = new BN("1"); // DOL
-    const amount = new BN("10000000000000000000"); // 10 units
+    const amount = new BN("10000000000000"); // 10 units
 
     let tx = MantaUtilities.publicTransferBuild(privateWallet.api, assetId, amount, destinationAddress);
 

--- a/manta-js/package/src/utils.ts
+++ b/manta-js/package/src/utils.ts
@@ -50,7 +50,7 @@ export class MantaUtilities {
   static async publicTransferSend(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address, senderAddress:Address, polkadotSigner:Signer): Promise<void> {
     api.setSigner(polkadotSigner);
     try {
-      const tx = this.publicTransferBuild(api, assetId, amount, destinationAddress);
+      const tx = await this.publicTransferBuild(api, assetId, amount, destinationAddress);
       await tx.signAndSend(senderAddress);
     } catch (e) {
       console.log('Failed to execute public transfer.');
@@ -59,10 +59,10 @@ export class MantaUtilities {
   }
 
   /// Creates a public transfer payload.
-  static publicTransferBuild(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address): any {
+  static async publicTransferBuild(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address): Promise<any> {
     const assetIdArray = Array.from(MantaPrivateWallet.assetIdToUInt8Array(assetId));
       const amountBN = amount.toArray('le', 16);
-      const tx = api.tx.mantaPay.publicTransfer(
+      const tx = await api.tx.mantaPay.publicTransfer(
         { id: assetIdArray, value: amountBN },
         destinationAddress
       );

--- a/manta-js/package/src/utils.ts
+++ b/manta-js/package/src/utils.ts
@@ -46,20 +46,26 @@ export class MantaUtilities {
     }
   }
 
-  /// Executes a public transfer.
-  static async publicTransfer(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address, senderAddress:Address, polkadotSigner:Signer): Promise<void> {
+  /// Builds, signs and sends a public transfer transaction.
+  static async publicTransferSend(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address, senderAddress:Address, polkadotSigner:Signer): Promise<void> {
     api.setSigner(polkadotSigner);
     try {
-      const assetIdArray = Array.from(MantaPrivateWallet.assetIdToUInt8Array(assetId));
-      const amountBN = amount.toArray('le', 16);
-      const tx = await api.tx.mantaPay.publicTransfer(
-        { id: assetIdArray, value: amountBN },
-        destinationAddress
-      );
+      const tx = this.publicTransferBuild(api, assetId, amount, destinationAddress);
       await tx.signAndSend(senderAddress);
     } catch (e) {
       console.log('Failed to execute public transfer.');
       console.error(e);
     }
+  }
+
+  /// Creates a public transfer payload.
+  static publicTransferBuild(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address): any {
+    const assetIdArray = Array.from(MantaPrivateWallet.assetIdToUInt8Array(assetId));
+      const amountBN = amount.toArray('le', 16);
+      const tx = api.tx.mantaPay.publicTransfer(
+        { id: assetIdArray, value: amountBN },
+        destinationAddress
+      );
+      return tx;
   }
 }

--- a/manta-js/package/src/utils.ts
+++ b/manta-js/package/src/utils.ts
@@ -1,5 +1,5 @@
 import { Version, Address } from './sdk.interfaces';
-import { Signer } from '@polkadot/api/types';
+import { Signer, SubmittableExtrinsic } from '@polkadot/api/types';
 import { bnToU8a } from '@polkadot/util';
 import axios from 'axios';
 import config from './manta-config.json';
@@ -51,12 +51,7 @@ export class MantaUtilities {
   static async publicTransferSend(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address, senderAddress:Address, polkadotSigner:Signer): Promise<void> {
     api.setSigner(polkadotSigner);
     try {
-      const assetIdArray = bnToU8a(assetId, {bitLength: 256});
-      const amountBN = amount.toArray('le', 16);
-      const tx = await api.tx.mantaPay.publicTransfer(
-        { id: assetIdArray, value: amountBN },
-        destinationAddress
-      );
+      const tx = await this.publicTransferBuild(api, assetId, amount, destinationAddress);
       await tx.signAndSend(senderAddress);
     } catch (e) {
       console.log('Failed to execute public transfer.');
@@ -65,8 +60,8 @@ export class MantaUtilities {
   }
 
   /// Creates a public transfer payload.
-  static async publicTransferBuild(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address): Promise<any> {
-    const assetIdArray = Array.from(MantaPrivateWallet.assetIdToUInt8Array(assetId));
+  static async publicTransferBuild(api:ApiPromise, assetId: BN, amount: BN, destinationAddress: Address): Promise<SubmittableExtrinsic<'promise', any>> {
+    const assetIdArray = bnToU8a(assetId, {bitLength: 256}); 
       const amountBN = amount.toArray('le', 16);
       const tx = await api.tx.mantaPay.publicTransfer(
         { id: assetIdArray, value: amountBN },


### PR DESCRIPTION
closes #91 

* Rename publicTransfer to publicTransferSend to follow the established send/build convention
* Added the missing publicTransferBuild variant and example how to use it.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/sdk/blob/main/CHANGELOG.md) and added the appropriate `L-` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.

