### PR TITLE
Fix: Ledger Read Bug

### DIFF
--- a/manta-js/CHANGELOG.md
+++ b/manta-js/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- [\#96](https://github.com/Manta-Network/sdk/pull/96) Fixed Ledger Read deserialization error.
 
 ### Security
 

--- a/manta-js/package/src/api/index.js
+++ b/manta-js/package/src/api/index.js
@@ -183,7 +183,7 @@ export default class Api {
         );
       }
       const pull_result = {
-        should_continue: result.should_continue,
+        should_continue: Boolean(result.should_continue),
         receivers: receivers,
         senders: senders,
       };


### PR DESCRIPTION
Fixed the Ledger Read Bug deserialization error, which was causing "restart" and "sync" to always fail.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/sdk/blob/main/CHANGELOG.md) and added the appropriate `L-` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.

