### PR TITLE
 chore: update calamari websocket url

### DIFF
--- a/manta-js/package/package.json
+++ b/manta-js/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta.js",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "manta.js sdk",
   "main": "./dist/browser/index.js",
   "exports": {

--- a/manta-js/package/src/manta-config.json
+++ b/manta-js/package/src/manta-config.json
@@ -13,7 +13,7 @@
         },
         "Calamari": {
             "name": "Calamari",
-            "ws": "wss://ws.calamari.systems/",
+            "ws": "wss://calamari.systems/",
             "ws_local": "ws://127.0.0.1:9944",
             "parachainId": 2084,
             "decimals": 12,


### PR DESCRIPTION
---
wss://ws.calamari.systems/ is under ddosing, front-end should switch to a healthy network.

Before we can merge this PR, please make sure that all the following items have been checked off:

- [ ] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/sdk/blob/main/CHANGELOG.md) and added the appropriate `L-` label to the PR.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.

